### PR TITLE
[BW-008] Gold entity graph generator

### DIFF
--- a/brain_wrought_engine/fixtures/__init__.py
+++ b/brain_wrought_engine/fixtures/__init__.py
@@ -7,6 +7,7 @@ BW-014: dirty-schema fixture generator (Phase 2).
 """
 
 from brain_wrought_engine.fixtures.generator import generate_brain
+from brain_wrought_engine.fixtures.gold_graph import REQUIRED_FRONTMATTER_KEYS
 from brain_wrought_engine.fixtures.validator import validate_brain
 
-__all__ = ["generate_brain", "validate_brain"]
+__all__ = ["generate_brain", "validate_brain", "REQUIRED_FRONTMATTER_KEYS"]

--- a/brain_wrought_engine/fixtures/gold_graph.py
+++ b/brain_wrought_engine/fixtures/gold_graph.py
@@ -35,6 +35,13 @@ from brain_wrought_engine.text_utils import slug
 NoteType = Literal["person", "project", "meeting", "topic"]
 EdgeType = Literal["mentions", "meeting_with", "about_project", "authored_by"]
 
+REQUIRED_FRONTMATTER_KEYS: dict[NoteType, frozenset[str]] = {
+    "person":  frozenset({"type", "created", "updated", "tags", "role"}),
+    "project": frozenset({"type", "created", "updated", "status", "owner"}),
+    "meeting": frozenset({"type", "date", "attendees", "project"}),
+    "topic":   frozenset({"type", "tags"}),
+}
+
 # ---------------------------------------------------------------------------
 # Pydantic models
 # ---------------------------------------------------------------------------
@@ -63,7 +70,6 @@ class GoldGraph(BaseModel):
     seed: int
     nodes: dict[str, GoldNode]  # key is note_id
     edges: tuple[GoldEdge, ...]  # sorted by (source_id, target_id, edge_type) for determinism
-    generated_at: str  # ISO 8601
 
     model_config = {"frozen": True}
 
@@ -378,13 +384,10 @@ def generate_gold_graph(
         sorted(edges, key=lambda e: (e.source_id, e.target_id, e.edge_type))
     )
 
-    generated_at = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-
     graph = GoldGraph(
         seed=seed,
         nodes=nodes,
         edges=sorted_edges,
-        generated_at=generated_at,
     )
 
     # ------------------------------------------------------------------

--- a/brain_wrought_engine/fixtures/gold_graph.py
+++ b/brain_wrought_engine/fixtures/gold_graph.py
@@ -1,0 +1,414 @@
+"""Gold entity graph generator for the ingestion axis.
+
+Edge types and resolution rules are deliberately narrow. A submission's
+backlink F1 is meaningful only if gold and submission both follow the
+same rules. Ambiguity here corrupts every downstream scorer.
+
+Edge resolution rules:
+- "mentions": source note body text contains target entity name literally.
+- "meeting_with": meeting notes only; attendees who have their own
+  people/ note each get a "meeting_with" edge from the meeting node.
+- "about_project": note frontmatter has a `project:` field whose slug
+  matches an existing project note_id.
+- "authored_by": meeting and project notes with an `author:` frontmatter
+  field that resolves via slug to a people note.
+
+Determinism class: FULLY_DETERMINISTIC — no LLM calls, no random
+sampling beyond the seeded rng used for timestamps and ordering.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel
+
+from brain_wrought_engine.text_utils import slug
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+NoteType = Literal["person", "project", "meeting", "topic"]
+EdgeType = Literal["mentions", "meeting_with", "about_project", "authored_by"]
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class GoldNode(BaseModel):
+    note_id: str
+    title: str
+    note_type: NoteType
+    frontmatter: dict[str, str]
+    expected_content_facets: list[str]  # key facts the note SHOULD contain
+    source_inbox_items: list[str]  # item_ids from the inbox that produced this node
+
+    model_config = {"frozen": True}
+
+
+class GoldEdge(BaseModel):
+    source_id: str
+    target_id: str
+    edge_type: EdgeType
+
+    model_config = {"frozen": True}
+
+
+class GoldGraph(BaseModel):
+    seed: int
+    nodes: dict[str, GoldNode]  # key is note_id
+    edges: tuple[GoldEdge, ...]  # sorted by (source_id, target_id, edge_type) for determinism
+    generated_at: str  # ISO 8601
+
+    model_config = {"frozen": True}
+
+
+# ---------------------------------------------------------------------------
+# Input types
+# ---------------------------------------------------------------------------
+
+
+class PersonEntity(BaseModel):
+    name: str  # "Alice Chen"
+    role: str  # "engineer", "manager", etc.
+    email: str  # derived: alice.chen@example.com
+
+
+class ProjectEntity(BaseModel):
+    name: str  # "Project Helios"
+    status: str  # "active", "planning", "complete"
+    owner: str  # person name
+
+
+class CrossReference(BaseModel):
+    source_item_id: str  # e.g. "email_0003"
+    mentioned_people: list[str]
+    mentioned_projects: list[str]
+    event_date: str | None  # ISO 8601 if this is a meeting/calendar item
+    attendees: list[str] | None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _seeded_iso_date(rng: random.Random, base: datetime) -> str:
+    """Return a seeded ISO 8601 date string near base."""
+    offset = rng.randint(0, 364)
+    dt = base + timedelta(days=offset)
+    return dt.strftime("%Y-%m-%d")
+
+
+def _render_frontmatter(fm: dict[str, str]) -> str:
+    lines = ["---"]
+    for k, v in fm.items():
+        lines.append(f"{k}: {v}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _render_note(node: GoldNode, outbound_targets: list[str]) -> str:
+    """Render a GoldNode to Obsidian-style Markdown."""
+    fm_block = _render_frontmatter(node.frontmatter)
+    body_paragraphs = "\n\n".join(node.expected_content_facets)
+    wikilinks = " ".join(f"[[{t}]]" for t in outbound_targets)
+    wikilink_section = f"\n\n{wikilinks}" if wikilinks else ""
+    return f"{fm_block}\n\n# {node.title}\n\n{body_paragraphs}{wikilink_section}\n"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_gold_graph(
+    *,
+    seed: int,
+    people: list[PersonEntity],
+    projects: list[ProjectEntity],
+    cross_references: list[CrossReference],
+    out_dir: Path | None = None,
+) -> GoldGraph:
+    """Generate a fully deterministic gold entity graph from structured inputs.
+
+    Parameters
+    ----------
+    seed:
+        Master seed for the seeded RNG — controls timestamp generation and
+        ordering.  No other randomness is used.
+    people:
+        Person entities to materialise as person-type nodes.
+    projects:
+        Project entities to materialise as project-type and companion topic nodes.
+    cross_references:
+        Cross-reference records linking inbox items to entities.  Records that
+        carry ``attendees`` are treated as meeting/calendar items and generate
+        meeting-type nodes.
+    out_dir:
+        Optional output directory.  When provided:
+        - ``out_dir/gold_graph.json`` is written (pretty-printed JSON).
+        - ``out_dir/gold_brain/`` is populated with one ``.md`` file per node.
+
+    Returns
+    -------
+    GoldGraph
+        Fully constructed, immutable gold graph.
+    """
+    rng = random.Random(seed)
+    base_date = datetime(2026, 1, 1, tzinfo=UTC)
+
+    nodes: dict[str, GoldNode] = {}
+
+    # ------------------------------------------------------------------
+    # 1. Build a lookup: person name → list of project names they appear in
+    # ------------------------------------------------------------------
+    person_projects: dict[str, list[str]] = {p.name: [] for p in people}
+    for xref in cross_references:
+        for person_name in xref.mentioned_people:
+            if person_name in person_projects:
+                for proj_name in xref.mentioned_projects:
+                    if proj_name not in person_projects[person_name]:
+                        person_projects[person_name].append(proj_name)
+
+    # ------------------------------------------------------------------
+    # 2. Person nodes
+    # ------------------------------------------------------------------
+    for person in people:
+        note_id = slug(person.name)
+        created = _seeded_iso_date(rng, base_date)
+        updated = _seeded_iso_date(rng, base_date)
+        fm: dict[str, str] = {
+            "type": "person",
+            "created": created,
+            "updated": updated,
+            "tags": "person",
+            "role": person.role,
+        }
+        facets: list[str] = [
+            f"{person.name} is a {person.role}.",
+            f"Email: {person.email}",
+        ]
+        for proj_name in person_projects.get(person.name, []):
+            facets.append(f"{person.name} is referenced in relation to {proj_name}.")
+
+        # Collect source_inbox_items where this person is mentioned
+        source_items = [
+            xref.source_item_id
+            for xref in cross_references
+            if person.name in xref.mentioned_people
+        ]
+
+        nodes[note_id] = GoldNode(
+            note_id=note_id,
+            title=person.name,
+            note_type="person",
+            frontmatter=fm,
+            expected_content_facets=facets,
+            source_inbox_items=source_items,
+        )
+
+    # ------------------------------------------------------------------
+    # 3. Project nodes  (+ author frontmatter = slug of owner)
+    # ------------------------------------------------------------------
+    for project in projects:
+        note_id = slug(project.name)
+        created = _seeded_iso_date(rng, base_date)
+        updated = _seeded_iso_date(rng, base_date)
+        owner_slug = slug(project.owner)
+        fm = {
+            "type": "project",
+            "created": created,
+            "updated": updated,
+            "status": project.status,
+            "owner": owner_slug,
+            "author": owner_slug,
+        }
+        facets = [
+            f"{project.name} has status: {project.status}.",
+            f"Owner: {project.owner}",
+        ]
+        source_items = [
+            xref.source_item_id
+            for xref in cross_references
+            if project.name in xref.mentioned_projects
+        ]
+        nodes[note_id] = GoldNode(
+            note_id=note_id,
+            title=project.name,
+            note_type="project",
+            frontmatter=fm,
+            expected_content_facets=facets,
+            source_inbox_items=source_items,
+        )
+
+    # ------------------------------------------------------------------
+    # 4. Topic nodes  (companion to each project)
+    # ------------------------------------------------------------------
+    for project in projects:
+        note_id = f"topic_{slug(project.name)}"
+        proj_slug = slug(project.name)
+        fm = {
+            "type": "topic",
+            "tags": "topic",
+            "project": proj_slug,  # enables Rule 3 ("about_project") → non-orphan
+        }
+        facets = [
+            f"Topic area for {project.name}.",
+        ]
+        nodes[note_id] = GoldNode(
+            note_id=note_id,
+            title=f"Topic: {project.name}",
+            note_type="topic",
+            frontmatter=fm,
+            expected_content_facets=facets,
+            source_inbox_items=[],
+        )
+
+    # ------------------------------------------------------------------
+    # 5. Meeting nodes  (cross_references with attendees)
+    # ------------------------------------------------------------------
+    for xref in cross_references:
+        if xref.attendees is None:
+            continue
+        note_id = f"meeting_{xref.source_item_id}"
+        event_date = xref.event_date or _seeded_iso_date(rng, base_date)
+        attendee_slugs = ", ".join(slug(a) for a in xref.attendees)
+        proj_slug = slug(xref.mentioned_projects[0]) if xref.mentioned_projects else ""
+
+        # Determine author: first attendee who is a known person node
+        author_slug = ""
+        for attendee in xref.attendees:
+            candidate = slug(attendee)
+            if candidate in nodes:
+                author_slug = candidate
+                break
+
+        fm = {
+            "type": "meeting",
+            "date": event_date,
+            "attendees": attendee_slugs,
+            "project": proj_slug,
+        }
+        if author_slug:
+            fm["author"] = author_slug
+
+        facets = [
+            f"Meeting held on {event_date}.",
+            f"Attendees: {', '.join(xref.attendees)}",
+        ]
+        if xref.mentioned_projects:
+            facets.append(f"Related project: {xref.mentioned_projects[0]}.")
+
+        nodes[note_id] = GoldNode(
+            note_id=note_id,
+            title=f"Meeting {xref.source_item_id}",
+            note_type="meeting",
+            frontmatter=fm,
+            expected_content_facets=facets,
+            source_inbox_items=[xref.source_item_id],
+        )
+
+    # ------------------------------------------------------------------
+    # 6. Edge construction — apply the four resolution rules
+    # ------------------------------------------------------------------
+    edges: set[GoldEdge] = set()
+
+    person_node_ids = {nid for nid, n in nodes.items() if n.note_type == "person"}
+    project_node_ids = {nid for nid, n in nodes.items() if n.note_type == "project"}
+
+    # Build a reverse map: entity name → note_id for "mentions" resolution
+    # We check facets for literal entity names
+    name_to_node_id: dict[str, str] = {}
+    for nid, node in nodes.items():
+        name_to_node_id[node.title] = nid
+
+    for source_id, source_node in nodes.items():
+        # Rule 1: "mentions" — scan expected_content_facets for entity name literals
+        all_facets_text = " ".join(source_node.expected_content_facets)
+        for target_name, target_id in name_to_node_id.items():
+            if target_id == source_id:
+                continue
+            if target_name in all_facets_text:
+                edges.add(
+                    GoldEdge(source_id=source_id, target_id=target_id, edge_type="mentions")
+                )
+
+        # Rule 2: "meeting_with" — meeting nodes → attendee people nodes
+        if source_node.note_type == "meeting":
+            raw_attendees = source_node.frontmatter.get("attendees", "")
+            for attendee_slug in (s.strip() for s in raw_attendees.split(",") if s.strip()):
+                if attendee_slug in person_node_ids:
+                    edges.add(
+                        GoldEdge(
+                            source_id=source_id,
+                            target_id=attendee_slug,
+                            edge_type="meeting_with",
+                        )
+                    )
+
+        # Rule 3: "about_project" — any node with frontmatter["project"] resolving to a project
+        proj_ref = source_node.frontmatter.get("project", "")
+        if proj_ref and proj_ref in project_node_ids:
+            edges.add(
+                GoldEdge(
+                    source_id=source_id, target_id=proj_ref, edge_type="about_project"
+                )
+            )
+
+        # Rule 4: "authored_by" — meeting/project nodes with frontmatter["author"]
+        if source_node.note_type in ("meeting", "project"):
+            author_ref = source_node.frontmatter.get("author", "")
+            if author_ref and author_ref in person_node_ids:
+                edges.add(
+                    GoldEdge(
+                        source_id=source_id,
+                        target_id=author_ref,
+                        edge_type="authored_by",
+                    )
+                )
+
+    # Sort edges for determinism: (source_id, target_id, edge_type)
+    sorted_edges = tuple(
+        sorted(edges, key=lambda e: (e.source_id, e.target_id, e.edge_type))
+    )
+
+    generated_at = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    graph = GoldGraph(
+        seed=seed,
+        nodes=nodes,
+        edges=sorted_edges,
+        generated_at=generated_at,
+    )
+
+    # ------------------------------------------------------------------
+    # 7. Optional file output
+    # ------------------------------------------------------------------
+    if out_dir is not None:
+        out_path = Path(out_dir)
+        out_path.mkdir(parents=True, exist_ok=True)
+
+        # gold_graph.json
+        json_path = out_path / "gold_graph.json"
+        json_path.write_text(graph.model_dump_json(indent=2), encoding="utf-8")
+
+        # gold_brain/ vault — one .md per node
+        vault_dir = out_path / "gold_brain"
+        vault_dir.mkdir(parents=True, exist_ok=True)
+
+        # Build outbound edge map: source_id → list of target_ids
+        outbound: dict[str, list[str]] = {nid: [] for nid in nodes}
+        for edge in sorted_edges:
+            outbound[edge.source_id].append(edge.target_id)
+
+        for note_id, node in nodes.items():
+            md_content = _render_note(node, outbound[note_id])
+            (vault_dir / f"{note_id}.md").write_text(md_content, encoding="utf-8")
+
+    return graph

--- a/tests/fixtures/test_gold_graph.py
+++ b/tests/fixtures/test_gold_graph.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from brain_wrought_engine.fixtures.gold_graph import (
+    REQUIRED_FRONTMATTER_KEYS,
     CrossReference,
     GoldGraph,
     PersonEntity,
@@ -93,12 +94,8 @@ def test_determinism(
     assert g1.nodes == g2.nodes
     assert g1.edges == g2.edges
     assert g1.seed == g2.seed
-    # JSON files will differ only in generated_at (datetime.now()) — compare
-    # everything except that field.
     j1 = json.loads((out1 / "gold_graph.json").read_text())
     j2 = json.loads((out2 / "gold_graph.json").read_text())
-    j1.pop("generated_at")
-    j2.pop("generated_at")
     assert j1 == j2
 
 
@@ -137,12 +134,6 @@ def test_frontmatter_completeness(
     small_graph_inputs: tuple[list[PersonEntity], list[ProjectEntity], list[CrossReference]],
 ) -> None:
     """Every node has all required frontmatter keys for its note_type."""
-    required: dict[str, set[str]] = {
-        "person": {"type", "created", "updated", "tags", "role"},
-        "project": {"type", "created", "updated", "status", "owner"},
-        "meeting": {"type", "date", "attendees", "project"},
-        "topic": {"type", "tags"},
-    }
     people, projects, cross_refs = small_graph_inputs
     graph = generate_gold_graph(
         seed=42,
@@ -151,7 +142,7 @@ def test_frontmatter_completeness(
         cross_references=cross_refs,
     )
     for note_id, node in graph.nodes.items():
-        required_keys = required[node.note_type]
+        required_keys = REQUIRED_FRONTMATTER_KEYS[node.note_type]
         actual_keys = set(node.frontmatter.keys())
         missing = required_keys - actual_keys
         assert not missing, (

--- a/tests/fixtures/test_gold_graph.py
+++ b/tests/fixtures/test_gold_graph.py
@@ -1,0 +1,245 @@
+"""Tests for brain_wrought_engine.fixtures.gold_graph.
+
+Six tests:
+  1. test_determinism           — same seed → bit-identical gold_graph.json
+  2. test_all_edges_resolve     — every edge source/target exists in nodes
+  3. test_frontmatter_completeness — every node has all required frontmatter keys
+  4. test_materialized_vault_valid — every [[wikilink]] resolves to an existing .md
+  5. test_no_orphan_nodes       — every node is source OR target of at least one edge
+  6. test_json_roundtrip        — gold_graph.json parses back as a valid GoldGraph
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from brain_wrought_engine.fixtures.gold_graph import (
+    CrossReference,
+    GoldGraph,
+    PersonEntity,
+    ProjectEntity,
+    generate_gold_graph,
+)
+
+_WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def small_graph_inputs() -> (
+    tuple[list[PersonEntity], list[ProjectEntity], list[CrossReference]]
+):
+    """A small but non-trivial graph with two people, one project, and two cross-refs."""
+    people = [
+        PersonEntity(name="Alice Chen", role="engineer", email="alice.chen@example.com"),
+        PersonEntity(name="Bob Park", role="manager", email="bob.park@example.com"),
+    ]
+    projects = [
+        ProjectEntity(name="Project Helios", status="active", owner="Alice Chen"),
+    ]
+    cross_references = [
+        CrossReference(
+            source_item_id="email_0001",
+            mentioned_people=["Alice Chen", "Bob Park"],
+            mentioned_projects=["Project Helios"],
+            event_date=None,
+            attendees=None,
+        ),
+        CrossReference(
+            source_item_id="calendar_0001",
+            mentioned_people=["Alice Chen", "Bob Park"],
+            mentioned_projects=["Project Helios"],
+            event_date="2026-01-15",
+            attendees=["Alice Chen", "Bob Park"],
+        ),
+    ]
+    return people, projects, cross_references
+
+
+# ---------------------------------------------------------------------------
+# 1. Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_determinism(
+    tmp_path: Path,
+    small_graph_inputs: tuple[list[PersonEntity], list[ProjectEntity], list[CrossReference]],
+) -> None:
+    """Same seed → bit-identical gold_graph.json."""
+    people, projects, cross_refs = small_graph_inputs
+    out1 = tmp_path / "run1"
+    out2 = tmp_path / "run2"
+    g1 = generate_gold_graph(
+        seed=42,
+        people=people,
+        projects=projects,
+        cross_references=cross_refs,
+        out_dir=out1,
+    )
+    g2 = generate_gold_graph(
+        seed=42,
+        people=people,
+        projects=projects,
+        cross_references=cross_refs,
+        out_dir=out2,
+    )
+    assert g1.nodes == g2.nodes
+    assert g1.edges == g2.edges
+    assert g1.seed == g2.seed
+    # JSON files will differ only in generated_at (datetime.now()) — compare
+    # everything except that field.
+    j1 = json.loads((out1 / "gold_graph.json").read_text())
+    j2 = json.loads((out2 / "gold_graph.json").read_text())
+    j1.pop("generated_at")
+    j2.pop("generated_at")
+    assert j1 == j2
+
+
+# ---------------------------------------------------------------------------
+# 2. All edges resolve
+# ---------------------------------------------------------------------------
+
+
+def test_all_edges_resolve(
+    small_graph_inputs: tuple[list[PersonEntity], list[ProjectEntity], list[CrossReference]],
+) -> None:
+    """Every edge source and target exists in nodes."""
+    people, projects, cross_refs = small_graph_inputs
+    graph = generate_gold_graph(
+        seed=42,
+        people=people,
+        projects=projects,
+        cross_references=cross_refs,
+    )
+    node_ids = set(graph.nodes.keys())
+    for edge in graph.edges:
+        assert edge.source_id in node_ids, (
+            f"Edge source {edge.source_id!r} not found in nodes"
+        )
+        assert edge.target_id in node_ids, (
+            f"Edge target {edge.target_id!r} not found in nodes"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Frontmatter completeness
+# ---------------------------------------------------------------------------
+
+
+def test_frontmatter_completeness(
+    small_graph_inputs: tuple[list[PersonEntity], list[ProjectEntity], list[CrossReference]],
+) -> None:
+    """Every node has all required frontmatter keys for its note_type."""
+    required: dict[str, set[str]] = {
+        "person": {"type", "created", "updated", "tags", "role"},
+        "project": {"type", "created", "updated", "status", "owner"},
+        "meeting": {"type", "date", "attendees", "project"},
+        "topic": {"type", "tags"},
+    }
+    people, projects, cross_refs = small_graph_inputs
+    graph = generate_gold_graph(
+        seed=42,
+        people=people,
+        projects=projects,
+        cross_references=cross_refs,
+    )
+    for note_id, node in graph.nodes.items():
+        required_keys = required[node.note_type]
+        actual_keys = set(node.frontmatter.keys())
+        missing = required_keys - actual_keys
+        assert not missing, (
+            f"Node {note_id!r} (type={node.note_type!r}) missing frontmatter keys: {missing}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Materialized vault — all wikilinks resolve
+# ---------------------------------------------------------------------------
+
+
+def test_materialized_vault_valid(
+    tmp_path: Path,
+    small_graph_inputs: tuple[list[PersonEntity], list[ProjectEntity], list[CrossReference]],
+) -> None:
+    """Every [[wikilink]] in the markdown vault resolves to an existing .md file."""
+    people, projects, cross_refs = small_graph_inputs
+    generate_gold_graph(
+        seed=42,
+        people=people,
+        projects=projects,
+        cross_references=cross_refs,
+        out_dir=tmp_path,
+    )
+    vault_dir = tmp_path / "gold_brain"
+    md_files = list(vault_dir.glob("*.md"))
+    assert md_files, "gold_brain/ directory is empty"
+
+    existing_stems = {f.stem for f in md_files}
+    broken: list[str] = []
+
+    for md_file in md_files:
+        content = md_file.read_text(encoding="utf-8")
+        for target in _WIKILINK_RE.findall(content):
+            if target not in existing_stems:
+                broken.append(f"{md_file.name}: [[{target}]]")
+
+    assert not broken, "Broken wikilinks found:\n" + "\n".join(broken)
+
+
+# ---------------------------------------------------------------------------
+# 5. No orphan nodes
+# ---------------------------------------------------------------------------
+
+
+def test_no_orphan_nodes(
+    small_graph_inputs: tuple[list[PersonEntity], list[ProjectEntity], list[CrossReference]],
+) -> None:
+    """Every node appears as source OR target of at least one edge."""
+    people, projects, cross_refs = small_graph_inputs
+    graph = generate_gold_graph(
+        seed=42,
+        people=people,
+        projects=projects,
+        cross_references=cross_refs,
+    )
+    connected: set[str] = set()
+    for edge in graph.edges:
+        connected.add(edge.source_id)
+        connected.add(edge.target_id)
+
+    orphans = set(graph.nodes.keys()) - connected
+    assert not orphans, f"Orphan nodes (no edges): {orphans}"
+
+
+# ---------------------------------------------------------------------------
+# 6. JSON roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_json_roundtrip(
+    tmp_path: Path,
+    small_graph_inputs: tuple[list[PersonEntity], list[ProjectEntity], list[CrossReference]],
+) -> None:
+    """gold_graph.json can be loaded back and parsed as GoldGraph."""
+    people, projects, cross_refs = small_graph_inputs
+    original = generate_gold_graph(
+        seed=42,
+        people=people,
+        projects=projects,
+        cross_references=cross_refs,
+        out_dir=tmp_path,
+    )
+    json_path = tmp_path / "gold_graph.json"
+    raw = json_path.read_text(encoding="utf-8")
+    restored = GoldGraph.model_validate_json(raw)
+
+    assert restored.seed == original.seed
+    assert restored.nodes == original.nodes
+    assert restored.edges == original.edges


### PR DESCRIPTION
## Summary

- New \`brain_wrought_engine/fixtures/gold_graph.py\`: \`generate_gold_graph()\` producing the deterministic ground-truth brain structure that a perfect ingestion system would produce
- Seven pydantic v2 frozen models: \`GoldNode\`, \`GoldEdge\`, \`GoldGraph\`, \`PersonEntity\`, \`ProjectEntity\`, \`CrossReference\`, plus \`NoteType\`/\`EdgeType\` Literal aliases
- Four node types: person, project, meeting, topic (one topic companion per project)
- Four edge resolution rules: \`mentions\`, \`meeting_with\`, \`about_project\`, \`authored_by\`
- Optional \`out_dir\` writes \`gold_graph.json\` + materialized \`gold_brain/\` Obsidian vault with wikilinks
- Fully deterministic: no LLM calls, seeded RNG only for timestamps

## Design decisions

- \`edges\` stored as \`tuple[GoldEdge, ...]\` sorted by \`(source_id, target_id, edge_type)\` — chosen over \`frozenset\` because pydantic \`model_dump_json()\` cannot serialize frozensets; deduplication achieved via \`set[GoldEdge]\` during construction
- Topic nodes carry \`frontmatter["project"]\` ensuring Rule 3 fires and no topic is ever orphaned
- Module docstring contains the full edge resolution rationale: "ambiguity here corrupts every downstream scorer"

## Tests

6 tests: determinism (structural + JSON), all edges resolve, frontmatter completeness, materialized vault wikilinks valid, no orphan nodes, JSON roundtrip. ruff clean, mypy strict clean.

Closes BW-008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)