### PR TITLE
[BW-013] Setup friction scorer

### DIFF
--- a/brain_wrought_engine/ingestion/__init__.py
+++ b/brain_wrought_engine/ingestion/__init__.py
@@ -2,3 +2,7 @@
 
 BW-009 through BW-013: implementation target for Phase 2.
 """
+
+from brain_wrought_engine.ingestion.setup_friction import SetupBlock, score_setup_friction
+
+__all__ = ["SetupBlock", "score_setup_friction"]

--- a/brain_wrought_engine/ingestion/setup_friction.py
+++ b/brain_wrought_engine/ingestion/setup_friction.py
@@ -1,0 +1,52 @@
+"""Setup friction scorer for the ingestion axis.
+
+Measures how much manual effort a user needed to configure an ingestion
+system. Lower friction → higher score. Score is in [0.0, 1.0].
+
+Scoring formula:
+    friction_actions = len(commands) + len(prompts) + len(config_files)
+    score = clamp(1.0 - friction_actions / 20.0, 0.0, 1.0)
+
+The denominator 20 is calibrated for v1; adjust in v1.1 based on
+observed submission distributions. auto_detected entries are free —
+they represent work the system did itself and do not penalize the score.
+
+Determinism class: FULLY_DETERMINISTIC — pure function of input.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SetupBlock(BaseModel):
+    """The `setup:` block from submission.yaml."""
+
+    commands: list[str] = Field(default_factory=list)
+    prompts: list[str] = Field(default_factory=list)
+    config_files: list[str] = Field(default_factory=list)
+    auto_detected: list[str] = Field(default_factory=list)
+
+    model_config = {"frozen": True}
+
+
+_MAX_FRICTION_ACTIONS: int = 20
+
+
+def score_setup_friction(setup: SetupBlock) -> float:
+    """Score the setup friction for an ingestion submission.
+
+    Parameters
+    ----------
+    setup:
+        The setup block from the submission's configuration.
+
+    Returns
+    -------
+    float
+        Friction score in [0.0, 1.0]. 1.0 = zero friction (fully automatic);
+        0.0 = maximum friction (20+ manual actions required).
+    """
+    friction_actions = len(setup.commands) + len(setup.prompts) + len(setup.config_files)
+    raw = 1.0 - friction_actions / _MAX_FRICTION_ACTIONS
+    return max(0.0, min(1.0, raw))

--- a/docs/SUBMISSION_PROTOCOL.md
+++ b/docs/SUBMISSION_PROTOCOL.md
@@ -1,0 +1,61 @@
+# Submission Protocol
+
+This document describes the `submission.yaml` schema and related conventions for
+submitting systems to the Brain-Wrought benchmark.
+
+---
+
+## submission.yaml schema
+
+A valid submission must include a `submission.yaml` file at the repo root. Required fields:
+
+```yaml
+submission_id: "my-system-v1"
+version: "1.0.0"
+axes:
+  - retrieval
+  - ingestion
+seed: 42
+```
+
+**Fields:**
+- `submission_id` — unique string identifier for this submission
+- `version` — semantic version of the submitted system
+- `axes` — list of axes the submission participates in (`retrieval`, `ingestion`, `assistant`)
+- `seed` — integer random seed; must be fixed and committed
+
+---
+
+## Setup block (ingestion axis)
+
+Submissions that participate in the **ingestion axis** must include a `setup:` block
+in `submission.yaml`. This block declares the manual effort required to configure the
+system. It is used by the setup-friction scorer (BW-013).
+
+```yaml
+setup:
+  commands:
+    - "pip install my-package"
+    - "python configure.py"
+  prompts:
+    - "Enter your API key"
+  config_files:
+    - "my_config.yaml"
+  auto_detected:
+    - "vault_path"
+    - "default_model"
+```
+
+**Fields:**
+- `commands` — shell commands the user must run manually (each command = 1 friction unit)
+- `prompts` — interactive prompts the user must answer (each prompt = 1 friction unit)
+- `config_files` — config files the user must author (each file = 1 friction unit)
+- `auto_detected` — config values the system derived automatically (**free** — do not add friction)
+
+**Scoring:**
+```
+friction_score = clamp(1.0 - (commands + prompts + config_files) / 20.0, 0.0, 1.0)
+```
+
+The denominator 20 is the v1 calibration point. Submissions with zero manual actions
+score 1.0; submissions requiring 20+ manual actions score 0.0.

--- a/tests/ingestion/test_setup_friction.py
+++ b/tests/ingestion/test_setup_friction.py
@@ -1,0 +1,79 @@
+"""Tests for brain_wrought_engine.ingestion.setup_friction."""
+from __future__ import annotations
+
+from brain_wrought_engine.ingestion.setup_friction import SetupBlock, score_setup_friction
+
+
+def test_zero_friction() -> None:
+    """Empty setup lists → score 1.0."""
+    setup = SetupBlock()
+    assert score_setup_friction(setup) == 1.0
+
+
+def test_max_friction_exact() -> None:
+    """Exactly 20 combined actions → score 0.0."""
+    setup = SetupBlock(
+        commands=["cmd"] * 10,
+        prompts=["prompt"] * 5,
+        config_files=["file"] * 5,
+    )
+    assert score_setup_friction(setup) == 0.0
+
+
+def test_beyond_max_clamped() -> None:
+    """More than 20 actions → clamped to 0.0, not negative."""
+    setup = SetupBlock(
+        commands=["cmd"] * 30,
+        prompts=["prompt"] * 20,
+    )
+    assert score_setup_friction(setup) == 0.0
+
+
+def test_auto_detected_does_not_penalize() -> None:
+    """auto_detected entries are free — they do not reduce the score."""
+    setup_with = SetupBlock(auto_detected=["api_key", "vault_path", "llm_model"] * 10)
+    setup_without = SetupBlock()
+    assert score_setup_friction(setup_with) == score_setup_friction(setup_without) == 1.0
+
+
+def test_real_example_good() -> None:
+    """A 'good' system: 1 command, 0 prompts, 0 config files → ~0.95."""
+    setup = SetupBlock(commands=["pip install brain-wrought-submission"])
+    score = score_setup_friction(setup)
+    assert abs(score - 0.95) < 1e-9
+
+
+def test_real_example_typical() -> None:
+    """A 'typical' system: 3 commands, 2 prompts, 1 config → ~0.70."""
+    setup = SetupBlock(
+        commands=["git clone ...", "pip install -r requirements.txt", "python setup.py"],
+        prompts=["Enter API key:", "Select vault path:"],
+        config_files=["config.yaml"],
+    )
+    score = score_setup_friction(setup)
+    assert abs(score - 0.70) < 1e-9
+
+
+def test_real_example_painful() -> None:
+    """A 'painful' system: 8 commands + 6 prompts + 3 config files → 0.15."""
+    setup = SetupBlock(
+        commands=["cmd"] * 8,
+        prompts=["prompt"] * 6,
+        config_files=["file"] * 3,
+    )
+    score = score_setup_friction(setup)
+    assert abs(score - 0.15) < 1e-9
+
+
+def test_score_in_unit_interval() -> None:
+    """Score is always in [0.0, 1.0] regardless of input."""
+    for n in range(0, 50, 5):
+        setup = SetupBlock(commands=["x"] * n)
+        s = score_setup_friction(setup)
+        assert 0.0 <= s <= 1.0
+
+
+def test_idempotent() -> None:
+    """Calling score_setup_friction twice with the same input returns the same result."""
+    setup = SetupBlock(commands=["a", "b"], prompts=["c"])
+    assert score_setup_friction(setup) == score_setup_friction(setup)


### PR DESCRIPTION
## Summary

- New \`brain_wrought_engine/ingestion/setup_friction.py\`: \`SetupBlock\` pydantic v2 model + \`score_setup_friction()\` pure function
- Score = clamp(1 − friction_actions/20, 0, 1); \`auto_detected\` entries are free
- New \`docs/SUBMISSION_PROTOCOL.md\` documenting the \`setup:\` block schema and scoring formula
- 9 tests: zero friction, max exact (0.0), beyond-max clamp, auto_detected exempt, three calibration points (0.95/0.70/0.15), unit-interval sweep, idempotence

## Design decisions

- Denominator 20 is the v1 calibration point (documented in module docstring); adjust in v1.1 based on observed submission distributions
- \`SUBMISSION_PROTOCOL.md\` created at \`docs/\` within the engine repo; the canonical version in brain-wrought-skills will need a corresponding update

ruff clean, mypy strict clean (2 source files).

Closes BW-013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)