### PR TITLE
ci: scaffold GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.3"
+
+      - name: Cache Poetry dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
+      - name: Install Poetry
+        run: pip install poetry --quiet
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Lint (ruff)
+        run: poetry run ruff check .
+
+      - name: Type check (mypy)
+        # brain_wrought_engine/fixtures/generator.py excluded: pre-existing BW-001 debt
+        # (missing anthropic stub, stale type: ignore). Track and fix separately.
+        run: poetry run mypy brain_wrought_engine/ --exclude brain_wrought_engine/fixtures/generator.py
+
+      - name: Test (pytest)
+        run: poetry run pytest -q --cov-fail-under=70


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` to run on every push and PR to main.

**Steps:** checkout → Python 3.12.3 → poetry cache → poetry install → ruff check → mypy (brain_wrought_engine/ excluding fixtures/generator.py) → pytest with 70% coverage gate

**mypy exclusion:** `brain_wrought_engine/fixtures/generator.py` has 3 pre-existing errors from BW-001 (missing anthropic stub, stale type: ignore). Excluded from CI until fixed. All other modules are clean.

**Self-validating:** this PR is the first CI run.