### PR TITLE
[BW-011] Citation accuracy scorer

### DIFF
--- a/brain_wrought_engine/ingestion/__init__.py
+++ b/brain_wrought_engine/ingestion/__init__.py
@@ -3,7 +3,24 @@
 BW-009 through BW-013: implementation target for Phase 2.
 """
 
+from brain_wrought_engine.ingestion.citation_accuracy import (
+    CitationAccuracyInput,
+    CitationCounters,
+    SubmissionCitation,
+    compute_citation_counters,
+    score_citation_accuracy,
+)
 from brain_wrought_engine.ingestion.entity_recall import EntityRecallInput, score_entity_recall
 from brain_wrought_engine.ingestion.setup_friction import SetupBlock, score_setup_friction
 
-__all__ = ["EntityRecallInput", "SetupBlock", "score_entity_recall", "score_setup_friction"]
+__all__ = [
+    "CitationAccuracyInput",
+    "CitationCounters",
+    "EntityRecallInput",
+    "SetupBlock",
+    "SubmissionCitation",
+    "compute_citation_counters",
+    "score_citation_accuracy",
+    "score_entity_recall",
+    "score_setup_friction",
+]

--- a/brain_wrought_engine/ingestion/citation_accuracy.py
+++ b/brain_wrought_engine/ingestion/citation_accuracy.py
@@ -1,0 +1,107 @@
+"""Citation accuracy scorer for the ingestion axis.
+
+Measures the fraction of submitted citations that reference inbox items which
+actually exist in the evaluated manifest. Semantic correctness (does the note
+body actually describe something in the item?) is deferred to v1.1; this scorer
+performs existence-only validation.
+
+Scoring formula:
+    validity = valid_citations / total_citations
+
+Where a citation is VALID if its ``inbox_item_id`` is present in the manifest's
+item set (case-sensitive, exact match).
+
+Worked example:
+    manifest item IDs: {"email_0001", "slack_0002", "pdf_0003"}
+    submission citations:
+        note_id="meeting-notes", inbox_item_id="email_0001"   ← valid
+        note_id="meeting-notes", inbox_item_id="slack_9999"   ← invalid
+        note_id="project-log",   inbox_item_id="pdf_0003"     ← valid
+    → score = 2 / 3 ≈ 0.6667
+
+Edge case: if submission has zero citations, score is 1.0 (vacuously valid).
+
+Determinism class: FULLY_DETERMINISTIC — pure function of input.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from brain_wrought_engine.fixtures.inbox_generator import InboxManifest
+
+
+class SubmissionCitation(BaseModel):
+    """A single citation from a submitted note to an inbox item."""
+
+    note_id: str
+    inbox_item_id: str
+
+    model_config = {"frozen": True}
+
+
+class CitationAccuracyInput(BaseModel):
+    """All inputs needed to compute the citation accuracy score."""
+
+    manifest: InboxManifest
+    submission_citations: frozenset[SubmissionCitation]
+
+    model_config = {"frozen": True}
+
+
+class CitationCounters(BaseModel):
+    """Detailed citation counts for inspection, logging, and warnings."""
+
+    total_citations: int
+    valid_citations: int
+    invalid_citations: int
+    submission_has_any_citations: bool
+
+    model_config = {"frozen": True}
+
+
+def compute_citation_counters(input: CitationAccuracyInput) -> CitationCounters:
+    """Return detailed counts for inspection and warnings.
+
+    Parameters
+    ----------
+    input:
+        The manifest and submission citations to evaluate.
+
+    Returns
+    -------
+    CitationCounters
+        Counts of total, valid, and invalid citations, plus a flag indicating
+        whether the submission included any citations at all.
+    """
+    known_ids: frozenset[str] = frozenset(item.item_id for item in input.manifest.items)
+    total = len(input.submission_citations)
+    valid = sum(
+        1 for c in input.submission_citations if c.inbox_item_id and c.inbox_item_id in known_ids
+    )
+    return CitationCounters(
+        total_citations=total,
+        valid_citations=valid,
+        invalid_citations=total - valid,
+        submission_has_any_citations=total > 0,
+    )
+
+
+def score_citation_accuracy(input: CitationAccuracyInput) -> float:
+    """Return [0.0, 1.0] fraction of citations that reference real inbox items.
+
+    Parameters
+    ----------
+    input:
+        The manifest and submission citations to evaluate.
+
+    Returns
+    -------
+    float
+        Citation validity score in [0.0, 1.0].
+        Returns 1.0 when there are zero citations (vacuously valid).
+    """
+    counters = compute_citation_counters(input)
+    if counters.total_citations == 0:
+        return 1.0
+    return counters.valid_citations / counters.total_citations

--- a/tests/ingestion/test_citation_accuracy.py
+++ b/tests/ingestion/test_citation_accuracy.py
@@ -1,0 +1,255 @@
+"""Tests for brain_wrought_engine.ingestion.citation_accuracy (BW-011)."""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from brain_wrought_engine.fixtures.inbox_generator import InboxItem, InboxManifest
+from brain_wrought_engine.ingestion.citation_accuracy import (
+    CitationAccuracyInput,
+    CitationCounters,
+    SubmissionCitation,
+    compute_citation_counters,
+    score_citation_accuracy,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_GENERATED_AT = "2026-01-01T12:00:00Z"
+
+
+def _make_manifest(item_ids: list[str]) -> InboxManifest:
+    """Build a minimal InboxManifest containing only the given item IDs."""
+    items = [
+        InboxItem(
+            item_id=iid,
+            item_type="email",
+            file_path=f"emails/{iid}.eml",
+            source_timestamp=_GENERATED_AT,
+            referenced_entities=[],
+            referenced_projects=[],
+        )
+        for iid in item_ids
+    ]
+    return InboxManifest(
+        seed=42,
+        inbox_size="small",
+        generated_at=_GENERATED_AT,
+        entity_pool=[],
+        items=items,
+    )
+
+
+def _make_input(
+    item_ids: list[str],
+    citations: list[tuple[str, str]],
+) -> CitationAccuracyInput:
+    """Build CitationAccuracyInput from item_ids and (note_id, inbox_item_id) pairs."""
+    return CitationAccuracyInput(
+        manifest=_make_manifest(item_ids),
+        submission_citations=frozenset(
+            SubmissionCitation(note_id=n, inbox_item_id=i) for n, i in citations
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — score_citation_accuracy
+# ---------------------------------------------------------------------------
+
+
+def test_no_citations_returns_one() -> None:
+    """Zero citations → vacuously valid, score = 1.0."""
+    inp = _make_input(["email_0001", "slack_0002"], [])
+    assert score_citation_accuracy(inp) == 1.0
+
+
+def test_all_valid_returns_one() -> None:
+    """All cited items exist in manifest → score = 1.0."""
+    inp = _make_input(
+        ["email_0001", "slack_0002", "pdf_0003"],
+        [
+            ("note-a", "email_0001"),
+            ("note-a", "slack_0002"),
+            ("note-b", "pdf_0003"),
+        ],
+    )
+    assert score_citation_accuracy(inp) == 1.0
+
+
+def test_half_invalid_returns_half() -> None:
+    """2 valid, 2 invalid → score = 0.5."""
+    inp = _make_input(
+        ["email_0001", "slack_0002"],
+        [
+            ("note-a", "email_0001"),
+            ("note-a", "slack_0002"),
+            ("note-b", "ghost_9999"),
+            ("note-b", "ghost_8888"),
+        ],
+    )
+    assert score_citation_accuracy(inp) == 0.5
+
+
+def test_all_invalid_returns_zero() -> None:
+    """Every cited item_id is absent from manifest → score = 0.0."""
+    inp = _make_input(
+        ["email_0001"],
+        [
+            ("note-a", "ghost_9999"),
+            ("note-b", "ghost_8888"),
+        ],
+    )
+    assert score_citation_accuracy(inp) == 0.0
+
+
+def test_empty_inbox_item_id_counted_as_invalid() -> None:
+    """A citation with an empty inbox_item_id is invalid."""
+    inp = _make_input(
+        ["email_0001"],
+        [
+            ("note-a", "email_0001"),
+            ("note-b", ""),
+        ],
+    )
+    assert score_citation_accuracy(inp) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — compute_citation_counters
+# ---------------------------------------------------------------------------
+
+
+def test_counters_zero_citations() -> None:
+    """No citations → counters all zero, submission_has_any_citations=False."""
+    inp = _make_input(["email_0001"], [])
+    counters = compute_citation_counters(inp)
+    assert counters == CitationCounters(
+        total_citations=0,
+        valid_citations=0,
+        invalid_citations=0,
+        submission_has_any_citations=False,
+    )
+
+
+def test_counters_consistent_with_score() -> None:
+    """compute_citation_counters counts are consistent: valid + invalid == total."""
+    inp = _make_input(
+        ["email_0001", "slack_0002"],
+        [
+            ("note-a", "email_0001"),
+            ("note-b", "ghost_9999"),
+            ("note-c", "ghost_8888"),
+        ],
+    )
+    counters = compute_citation_counters(inp)
+    assert counters.valid_citations + counters.invalid_citations == counters.total_citations
+    assert counters.total_citations == 3
+    assert counters.valid_citations == 1
+    assert counters.invalid_citations == 2
+    assert counters.submission_has_any_citations is True
+
+
+def test_counters_all_valid() -> None:
+    """All citations valid → invalid_citations == 0."""
+    inp = _make_input(
+        ["email_0001", "slack_0002"],
+        [("note-a", "email_0001"), ("note-b", "slack_0002")],
+    )
+    counters = compute_citation_counters(inp)
+    assert counters.valid_citations == 2
+    assert counters.invalid_citations == 0
+    assert counters.submission_has_any_citations is True
+
+
+# ---------------------------------------------------------------------------
+# Multiple citations from one note count individually
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_citations_from_one_note_counted_individually() -> None:
+    """Two citations in the same note both count; each is checked independently."""
+    inp = _make_input(
+        ["email_0001", "slack_0002"],
+        [
+            ("meeting-notes", "email_0001"),
+            ("meeting-notes", "slack_0002"),
+        ],
+    )
+    counters = compute_citation_counters(inp)
+    assert counters.total_citations == 2
+    assert counters.valid_citations == 2
+
+
+# ---------------------------------------------------------------------------
+# Same citation from two different notes counts as two citations
+# ---------------------------------------------------------------------------
+
+
+def test_same_item_id_from_two_notes_counts_as_two() -> None:
+    """(note-a, email_0001) and (note-b, email_0001) are distinct citations."""
+    inp = _make_input(
+        ["email_0001"],
+        [
+            ("note-a", "email_0001"),
+            ("note-b", "email_0001"),
+        ],
+    )
+    counters = compute_citation_counters(inp)
+    assert counters.total_citations == 2
+    assert counters.valid_citations == 2
+    assert score_citation_accuracy(inp) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis property tests
+# ---------------------------------------------------------------------------
+
+_ITEM_IDS = st.text(min_size=1, max_size=12, alphabet="abcdefghijklmnopqrstuvwxyz0123456789_")
+_NOTE_IDS = st.text(min_size=1, max_size=12, alphabet="abcdefghijklmnopqrstuvwxyz-")
+
+
+@st.composite
+def _citation_accuracy_input(draw: st.DrawFn) -> CitationAccuracyInput:
+    """Strategy producing an arbitrary CitationAccuracyInput."""
+    item_id_list = draw(st.lists(_ITEM_IDS, min_size=0, max_size=10, unique=True))
+    note_id_list = draw(st.lists(_NOTE_IDS, min_size=0, max_size=5, unique=True))
+
+    all_possible_ids = item_id_list + draw(st.lists(_ITEM_IDS, min_size=0, max_size=5))
+
+    citation_pairs: list[tuple[str, str]] = []
+    if note_id_list and all_possible_ids:
+        raw = draw(
+            st.lists(
+                st.tuples(
+                    st.sampled_from(note_id_list),
+                    st.sampled_from(all_possible_ids),
+                ),
+                min_size=0,
+                max_size=15,
+            )
+        )
+        citation_pairs = list({(n, i) for n, i in raw})
+
+    return _make_input(item_id_list, citation_pairs)
+
+
+@settings(max_examples=300)
+@given(_citation_accuracy_input())
+def test_score_in_unit_interval(inp: CitationAccuracyInput) -> None:
+    """score_citation_accuracy always returns a value in [0.0, 1.0]."""
+    score = score_citation_accuracy(inp)
+    assert 0.0 <= score <= 1.0
+
+
+@settings(max_examples=300)
+@given(_citation_accuracy_input())
+def test_score_times_total_equals_valid(inp: CitationAccuracyInput) -> None:
+    """When total > 0: score * total == valid (integer arithmetic equivalence)."""
+    counters = compute_citation_counters(inp)
+    score = score_citation_accuracy(inp)
+    if counters.total_citations > 0:
+        assert abs(score * counters.total_citations - counters.valid_citations) < 1e-9


### PR DESCRIPTION
## Summary

- Implements `score_citation_accuracy` and `compute_citation_counters` under `brain_wrought_engine/ingestion/citation_accuracy.py`
- Scoring rule: `validity = valid_citations / total_citations`; zero citations → 1.0 (vacuously valid)
- Existence-only validation in v1 (semantic correctness deferred to v1.1 per spec)
- Exports added to `brain_wrought_engine/ingestion/__init__.py` alphabetically alongside existing exports

## Public API

- `SubmissionCitation` — frozen Pydantic model: `note_id`, `inbox_item_id`
- `CitationAccuracyInput` — frozen model wrapping `InboxManifest` + `frozenset[SubmissionCitation]`
- `CitationCounters` — frozen model: `total_citations`, `valid_citations`, `invalid_citations`, `submission_has_any_citations`
- `score_citation_accuracy(input) -> float` — returns [0.0, 1.0]
- `compute_citation_counters(input) -> CitationCounters` — returns detailed breakdown

## Test plan

- [ ] `test_no_citations_returns_one` — zero citations → 1.0, counters all zero
- [ ] `test_all_valid_returns_one` — perfect citations → 1.0
- [ ] `test_half_invalid_returns_half` — 2 valid / 4 total → 0.5
- [ ] `test_all_invalid_returns_zero` — every cited ID missing → 0.0
- [ ] `test_empty_inbox_item_id_counted_as_invalid` — empty string ID is invalid
- [ ] `test_counters_zero_citations` — counters struct equality check
- [ ] `test_counters_consistent_with_score` — valid + invalid == total
- [ ] `test_counters_all_valid` — invalid_citations == 0
- [ ] `test_multiple_citations_from_one_note_counted_individually` — per-citation not per-note
- [ ] `test_same_item_id_from_two_notes_counts_as_two` — uniqueness keyed by (note_id, inbox_item_id)
- [ ] `test_score_in_unit_interval` (Hypothesis, 300 examples) — 0.0 ≤ score ≤ 1.0
- [ ] `test_score_times_total_equals_valid` (Hypothesis, 300 examples) — arithmetic invariant

12 tests pass; `citation_accuracy.py` at 100% coverage; ruff clean; mypy strict clean on new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)